### PR TITLE
fix error in mpd_get_image_alt_tags

### DIFF
--- a/inc/mpd-functions.php
+++ b/inc/mpd-functions.php
@@ -638,7 +638,11 @@ function mpd_get_image_alt_tags($post_media_attachments){
 
         foreach ($post_media_attachments as $post_media_attachment) {
 
-            $alt_tag = get_post_meta($post_media_attachment->ID, '_wp_attachment_image_alt', true);
+            if(array_key_exists("object",$post_media_attachment))
+                $post_id = $post_media_attachment["object"]->ID;
+            else
+                $post_id = $post_media_attachment->ID;
+            $alt_tag = get_post_meta($post_id, '_wp_attachment_image_alt', true);
 
             $alt_tags_to_be_copied[$attachement_count] = $alt_tag;
 


### PR DESCRIPTION
The post_media_attachment object is an array with two values object and attached_file_path