### PR TITLE
extend filter parameters and fix issues

### DIFF
--- a/addons/bulkaction-mpd-addon.php
+++ b/addons/bulkaction-mpd-addon.php
@@ -139,7 +139,7 @@ function mpd_bulk_action() {
 
             );
 
-				do_action( 'mpd_single_batch_after', $post_id, $source_blog_id, $results[ $highest_index ][ 'id' ], $get_site[ 0 ]
+				do_action( 'mpd_single_batch_after', $post_id, $source_blog_id, $results[ $highest_index ][ 'id' ], $get_site[ 0 ]);
 
           }
 

--- a/addons/bulkaction-mpd-addon.php
+++ b/addons/bulkaction-mpd-addon.php
@@ -97,9 +97,18 @@ function mpd_bulk_action() {
   if (0 === strpos($action, 'dup')) {
       
       preg_match("/(?<=dup-)\d+/", $action, $get_site);
+      //JM fix for no $get_site and abort function for when not a site copy
+      if ( ! $get_site || count( $get_site ) == 0 ) {
+        return;
+      }
       
       if(isset($_REQUEST['post'])) {
-            $post_ids = array_map('intval', $_REQUEST['post']);
+          //JM: fix for when not array
+          if ( is_array( $_REQUEST[ 'post' ] ) ) {
+              $post_ids = array_map('intval', $_REQUEST['post']);
+          } else {
+              $post_ids[] = $_REQUEST[ 'post' ];
+          }
       }
 
       $results          = array();

--- a/addons/bulkaction-mpd-addon.php
+++ b/addons/bulkaction-mpd-addon.php
@@ -90,6 +90,7 @@ add_action('admin_footer-upload.php', 'mpd_bulk_admin_script');
  */
 function mpd_bulk_action() {
  
+	$source_blog_id	 = get_current_blog_id();
   $wp_list_table  = _get_list_table('WP_Posts_List_Table');
   $action         = $wp_list_table->current_action();
 
@@ -138,7 +139,7 @@ function mpd_bulk_action() {
 
             );
 
-            do_action('mpd_single_batch_after', $post_id);
+				do_action( 'mpd_single_batch_after', $post_id, $source_blog_id, $results[ $highest_index ][ 'id' ], $get_site[ 0 ]
 
           }
 

--- a/addons/posts-2-posts-addon.php
+++ b/addons/posts-2-posts-addon.php
@@ -1,0 +1,204 @@
+<?php
+
+// Load the posts-to-posts addon only if its network activated
+if (!function_exists('is_plugin_active_for_network')) {
+    require_once(ABSPATH . '/wp-admin/includes/plugin.php');
+}
+
+if (is_plugin_active_for_network('posts-to-posts/posts-to-posts.php')) {
+
+    $mpd_p2p_source_data = null;
+
+    function mpd_p2p_p2p_enrich(&$p2p_link) {
+        $tmp = (array) $p2p_link;
+        $tmp['meta'] = get_metadata('p2p', $p2p_link->p2p_id);
+        if($tmp['meta']){
+           foreach ($tmp['meta'] as $key => &$val) {
+                // everything is singular
+                $val = $val[0];
+            } 
+        }
+        
+        unset($val);
+        $p2p_link = (object) $tmp;
+    }
+
+    function mpd_p2p_prepare_source_data($source_post_id, $destination_blog_id) {
+        global $wpdb;
+        global $mpd_p2p_source_data;
+
+        $p2p_links = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT * FROM $wpdb->p2p WHERE p2p_from = %d OR p2p_to = %d",
+                $source_post_id, $source_post_id));
+        if($p2p_links){
+           foreach ($p2p_links as &$p2p_link) {
+                mpd_p2p_p2p_enrich($p2p_link);
+            } 
+        }
+        
+        unset($p2p_link);
+
+        $mpd_p2p_source_data = array(
+            'source_post_id' => $source_post_id,
+            'source_p2p_links' => $p2p_links,
+            'destination_blog_id' => $destination_blog_id,
+        );
+    }
+
+    function mpd_p2p_by_dest($mpd_links) {
+        $res = array();
+        if($mpd_links){
+            foreach ($mpd_links as $mpd_link) {
+                if (!array_key_exists($mpd_link->destination_id, $res)) {
+                    $res[$mpd_link->destination_id] = array();
+                }
+                array_push($res[$mpd_link->destination_id], $mpd_link->destination_post_id);
+            }
+        }
+        
+
+        return $res;
+    }
+
+    add_action("mpd_during_core_in_source", "mpd_p2p_pre_copy_persist", 10, 5);
+    add_action("mpd_persist_during_core_in_source", "mpd_p2p_pre_copy_persist", 10, 5);
+    function mpd_p2p_pre_copy_persist($mpd_post, $attached_image, $meta_values, $source_post_id, $destination_blog_id) {
+        if (!function_exists('p2p_register_connection_type')) {
+            return;
+        }
+
+        mpd_p2p_prepare_source_data($source_post_id, $destination_blog_id);
+    }
+
+    add_action("mpd_end_of_core_before_return", "mpd_p2p_after_create_update", 10, 3);
+    add_action("mpd_persist_end_of_core_before_return", "mpd_p2p_after_create_update", 10, 3);
+    function mpd_p2p_after_create_update($dest_post_id, $mpd_post, $source_blog_id) {
+        if (!function_exists('p2p_register_connection_type')) {
+            return;
+        }
+
+        global $mpd_p2p_source_data;
+
+        $source_post_id = $mpd_p2p_source_data['source_post_id'];
+        $destination_blog_id = $mpd_p2p_source_data['destination_blog_id'];
+        if($mpd_p2p_source_data['source_p2p_links']){
+            foreach ($mpd_p2p_source_data['source_p2p_links'] as $source_p2p_link) {
+                $source_p2p_other = ($source_post_id == $source_p2p_link->p2p_from ?
+                    $source_p2p_link->p2p_to : $source_p2p_link->p2p_from);
+                $mpd_links_of_p2p_link = mpd_get_persists_for_post($source_blog_id, $source_p2p_other);
+
+                if($mpd_links_of_p2p_link){
+                   foreach ($mpd_links_of_p2p_link as $mpd_link_of_p2p_link) {
+                        if ($mpd_link_of_p2p_link->destination_id != $destination_blog_id) {
+                            continue;
+                        }
+
+                        _mpd_p2p_copy_link_raw(
+                            true /* link */,
+                            $source_p2p_link /* meta and dir */,
+                            $source_post_id /* for dir */,
+                            $dest_post_id, /* the two new ids */
+                            $mpd_link_of_p2p_link->destination_post_id);
+                    } 
+                }
+                
+            }
+        }
+        
+    }
+
+    add_action('p2p_created_connection', 'mpd_p2p_created_connection', 10, 1);
+    function mpd_p2p_created_connection($p2p_id) {
+        _mpd_p2p_copy_link_by_id(true, $p2p_id);
+    }
+
+    add_action('p2p_delete_connections', 'mpd_p2p_delete_connections', 10, 1);
+    function mpd_p2p_delete_connections($p2p_ids) {
+        if($p2p_ids){
+            foreach ($p2p_ids as $p2p_id) {
+                _mpd_p2p_copy_link_by_id(false, $p2p_id);
+            }  
+        }
+        
+    }
+
+    function _mpd_p2p_copy_link_by_id($is_create, $p2p_id) {
+        $p2p = p2p_get_connection($p2p_id);
+        mpd_p2p_p2p_enrich($p2p);
+        $from_post_id = $p2p->p2p_from;
+        $to_post_id = $p2p->p2p_to;
+
+        foreach (mpd_get_persists_for_post(null, $from_post_id) as $from_mpd_link) {
+            foreach (mpd_get_persists_for_post(null, $to_post_id) as $to_mpd_link) {
+                if ($from_mpd_link->destination_id != $to_mpd_link->destination_id) {
+                    continue;
+                }
+
+                switch_to_blog($from_mpd_link->destination_id);
+
+                _mpd_p2p_copy_link_raw(
+                    $is_create,
+                    $p2p,
+                    $from_post_id,
+                    $from_mpd_link->destination_post_id,
+                    $to_mpd_link->destination_post_id);
+
+                restore_current_blog();
+            }
+        }
+    }
+
+    function _mpd_p2p_copy_link_raw($is_create, $p2p, $old_post_id, $new_post_id, $other_post_id) {
+        global $wpdb;
+
+        $from = $p2p->p2p_from == $old_post_id ? $new_post_id : $other_post_id;
+        $to = $p2p->p2p_from == $old_post_id ? $other_post_id : $new_post_id;
+
+        // NOTE: This whole thing does not handle multiple p2p connections for
+        // a pair of posts
+        $existing_p2p_link = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT * FROM $wpdb->p2p WHERE p2p_from = %d AND p2p_to = %d AND p2p_type = %s",
+                $from, $to, $p2p->p2p_type));
+
+
+        if (!$is_create) {
+            if (!is_null($existing_p2p_link)) {
+                p2p_delete_connection($existing_p2p_link->p2p_id);
+            }
+            return;
+        }
+
+        if (is_null($existing_p2p_link)) {
+            p2p_create_connection($p2p->p2p_type, array(
+                'from' => $from,
+                'to' => $to,
+                'meta' => $p2p->meta));
+        } else {
+            // exists, most likely the meta is good
+            $p2p_meta = get_metadata('p2p', $existing_p2p_link->p2p_id);
+            $expected_p2p_meta = $p2p->meta;
+
+            $are_same = true;
+            if (count($p2p_meta) == count($expected_p2p_meta)) {
+                foreach ($expected_p2p_meta as $key => $val) {
+                    if (!(array_key_exists($key, $p2p_meta) && $p2p_meta[$key] == $val)) {
+                        $are_same = false;
+                        break;
+                    }
+                }
+            } else {
+                $are_same = false;
+            }
+
+            if (!$are_same) {
+                // well, meta differs, wipe all and re-add
+                $wpdb->delete($wpdb->p2pmeta, array('p2p_id' => $existing_p2p_link->p2p_id), array('%d'));
+                foreach ($expected_p2p_meta as $key => $val) {
+                    p2p_add_meta($existing_p2p_link->p2p_id, $key, $val);
+                }
+            }
+        }
+    }
+}

--- a/addons/restrictSites-mpd-addon.php
+++ b/addons/restrictSites-mpd-addon.php
@@ -133,7 +133,7 @@ function master_site_settings_render(){
   $sites   = mpd_wp_get_sites();
 
    if($options = get_option( 'mdp_settings' )){
-		$mdp_restrict_master_label_value = $options['master_site_setting'];
+		$mdp_restrict_master_label_value = isset( $options[ 'master_site_setting' ] ) ? $options[ 'master_site_setting' ] : '';
 	};
   ?>
   
@@ -322,6 +322,7 @@ add_action( 'switch_blog', 'change_tax_terms_table', 0 );
 function change_tax_terms_table(){
 
 	$options 		= get_option( 'mdp_settings' );
+	if ( isset( $options[ 'master_site_setting' ] ) ) {
 	$master_id 		= $options['master_site_setting'];
 
 	if((isset($options['mdp_global_categories_taxonomies']) || !$options) && apply_filters('mdp_global_categories_taxonomies', true) ){
@@ -333,5 +334,5 @@ function change_tax_terms_table(){
 		    $wpdb->term_taxonomy = $wpdb->get_blog_prefix($master_id) . 'term_taxonomy';
 
         }
-    
+	}
 }

--- a/addons/restrictSites-mpd-addon.php
+++ b/addons/restrictSites-mpd-addon.php
@@ -188,7 +188,7 @@ function mdp_global_categories_taxonomies_render(  ) {
  */
 function mpd_add_addon_script_to_settings_page(){
 	
-	$screenid = get_current_screen()->id;
+	$screenid = (get_current_screen()) ? get_current_screen()->id : '';
 
 	if($screenid == 'settings_page_multisite_post_duplicator'){
 	?>

--- a/inc/core.php
+++ b/inc/core.php
@@ -47,6 +47,11 @@ function mpd_duplicate_over_multisite($post_id_to_copy, $new_blog_id, $post_type
     $options    = get_option( 'mdp_settings' );
     //Get the object of the post we are copying
     $mdp_post   = get_post($mpd_process_info['source_post_id']);
+	//if there is no valid post, we can't duplicate it
+	if ( ! $mdp_post ) {
+		error_log( 'id passed to mpd_duplicate_over_multisite could not be recognised as a valid post id:' . $post_id_to_copy );
+		return false;
+	}
     //Get the title of the post we are copying
     $title      = get_the_title($mdp_post);
     //Get the tags from the post we are copying
@@ -187,7 +192,10 @@ function mpd_duplicate_over_multisite($post_id_to_copy, $new_blog_id, $post_type
 
     //////////////////////////////////////
     //Go back to the current blog so we can update information about the action that just took place
-    restore_current_blog();
+	/* Contrary to the function's name, this does NOT restore the original blog but the previous blog. Calling `switch_to_blog()` twice in a row and then calling this function will result in being on the blog set by the first `switch_to_blog()` call...
+	 * so, restore_current_blog could lead to unexpected results if blog switching happens in any of the filter */
+	//restore_current_blog();
+	switch_to_blog( $source_blog_id );
     //////////////////////////////////////
 
     //Use the collected information about the new post to generate a status notice and a link for the user
@@ -360,7 +368,8 @@ function mpd_persist_over_multisite($persist_post) {
 
     //////////////////////////////////////
     //Go back to the current blog so we can update information about the action that just took place
-    restore_current_blog();
+	//restore_current_blog();
+	switch_to_blog( $persist_post->destination_id );
     //////////////////////////////////////
 
     //Use the collected information about the new post to generate a status notice and a link for the user

--- a/inc/core.php
+++ b/inc/core.php
@@ -52,12 +52,22 @@ function mpd_duplicate_over_multisite($post_id_to_copy, $new_blog_id, $post_type
 		error_log( 'id passed to mpd_duplicate_over_multisite could not be recognised as a valid post id:' . $post_id_to_copy );
 		return false;
 	}
+
+	//if the post is already duplicated to target blog, skip instead of duplicating again
+	$source_blog_id	 = get_current_blog_id();
+	$args			 = array(
+		'source_id'		 => $source_blog_id,
+		'destination_id' => $new_blog_id,
+		'source_post_id' => $post_id_to_copy,
+	);
+	if ( mpd_is_there_a_persist( $args ) ) {
+		return;
+	}
+
     //Get the title of the post we are copying
     $title      = get_the_title($mdp_post);
     //Get the tags from the post we are copying
     $sourcetags = wp_get_post_tags( $mpd_process_info['source_post_id'], array( 'fields' => 'names' ) );
-    //Get the ID of the sourse blog
-    $source_blog_id  = get_current_blog_id();
     //Get the categories for the post
     $source_categories = mpd_get_objects_of_post_categories($mpd_process_info['source_post_id'], $mpd_process_info['post_type']);
     //Get the taxonomy terms for the post

--- a/inc/core.php
+++ b/inc/core.php
@@ -131,9 +131,10 @@ function mpd_duplicate_over_multisite($post_id_to_copy, $new_blog_id, $post_type
     //Tell WordPress to work in the destination site
     switch_to_blog($mpd_process_info['destination_id']);
     ////////////////////////////////////////////////
-
-
-
+	//suppress excess save hooks from other plugins which may not apply in the destination blog
+	if ( ! defined( 'DOING_AUTOSAVE' ) ) {
+		define( 'DOING_AUTOSAVE', true );
+	}
     //Make the new post
     $post_id = wp_insert_post($mdp_post);
     
@@ -303,7 +304,10 @@ function mpd_persist_over_multisite($persist_post) {
     ////////////////////////////////////////////////
 
     global $wpdb;
-
+	//suppress excess save hooks from other plugins which may not apply in the destination blog
+	if ( ! defined( 'DOING_AUTOSAVE' ) ) {
+		define( 'DOING_AUTOSAVE', true );
+	}
     //Make the new post
     $post_id = wp_update_post($mdp_post);
 

--- a/inc/core.php
+++ b/inc/core.php
@@ -187,8 +187,7 @@ function mpd_duplicate_over_multisite($post_id_to_copy, $new_blog_id, $post_type
 
         if((isset($options['mdp_copy_post_taxonomies']) || !$options) && apply_filters('mdp_copy_post_taxonomies', true) ){
 
-            mpd_set_post_taxonomy_terms($post_id, $source_taxonomies);
-
+			mpd_set_post_taxonomy_terms( $post_id, $source_taxonomies, $source_blog_id );
         }
 
     }
@@ -363,8 +362,7 @@ function mpd_persist_over_multisite($persist_post) {
 
         if((isset($options['mdp_copy_post_taxonomies']) || !$options) && apply_filters('mdp_copy_post_taxonomies', true) ){
 
-            mpd_set_post_taxonomy_terms($post_id, $source_taxonomies);
-
+			mpd_set_post_taxonomy_terms( $post_id, $source_taxonomies, $source_blog_id );
         }
 
     }

--- a/inc/core.php
+++ b/inc/core.php
@@ -84,7 +84,8 @@ function mpd_duplicate_over_multisite($post_id_to_copy, $new_blog_id, $post_type
     ), $mpd_process_info);
 
     //Get all the meta data associated with the source post
-    $meta_values       = apply_filters('mpd_filter_post_meta', get_post_meta($mpd_process_info['source_post_id']));
+	$meta_values	 = apply_filters( 'mpd_filter_post_meta', get_post_meta( $mpd_process_info[ 'source_post_id' ] )
+	, $post_id_to_copy, 0, $source_blog_id, $new_blog_id );
     //Get array of data associated with the featured image for this post
     $featured_image    = mpd_get_featured_image_from_source($mpd_process_info['source_post_id']);
 
@@ -182,7 +183,7 @@ function mpd_duplicate_over_multisite($post_id_to_copy, $new_blog_id, $post_type
     $blog_details  = get_blog_details($mpd_process_info['destination_id']);
     $site_name     = $blog_details->blogname;
 
-    do_action('mpd_end_of_core_before_return', $post_id, $mdp_post, $source_blog_id);
+	do_action( 'mpd_end_of_core_before_return', $post_id, $mdp_post, $source_blog_id, $mpd_process_info[ 'source_post_id' ] );
 
     //////////////////////////////////////
     //Go back to the current blog so we can update information about the action that just took place
@@ -251,7 +252,9 @@ function mpd_persist_over_multisite($persist_post) {
     ), $persist_post);
 
     //Get all the meta data associated with the sourse post
-    $meta_values       = apply_filters('mpd_filter_persist_post_meta', get_post_meta($persist_post->source_post_id)) ;
+	$meta_values = apply_filters( 'mpd_filter_persist_post_meta', get_post_meta( $persist_post->source_post_id )
+	, $persist_post->source_post_id, $persist_post->destination_post_id, $source_blog_id, $persist_post->destination_id );
+
     //Get array of data associated with the featured image for this post
     $featured_image    = mpd_get_featured_image_from_source($persist_post->source_post_id);
 
@@ -353,7 +356,7 @@ function mpd_persist_over_multisite($persist_post) {
     $blog_details  = get_blog_details($persist_post->destination_id);
     $site_name     = $blog_details->blogname;
 
-    do_action('mpd_persist_end_of_core_before_return', $post_id, $mdp_post, $source_blog_id);
+	do_action( 'mpd_persist_end_of_core_before_return', $post_id, $mdp_post, $source_blog_id, $persist_post->source_post_id );
 
     //////////////////////////////////////
     //Go back to the current blog so we can update information about the action that just took place

--- a/inc/core.php
+++ b/inc/core.php
@@ -193,6 +193,7 @@ function mpd_duplicate_over_multisite($post_id_to_copy, $new_blog_id, $post_type
     }
     
     //Collect information about the new post 
+	switch_to_blog( $mpd_process_info[ 'destination_id' ] );
     $site_edit_url = get_edit_post_link( $post_id );
     $blog_details  = get_blog_details($mpd_process_info['destination_id']);
     $site_name     = $blog_details->blogname;
@@ -368,6 +369,7 @@ function mpd_persist_over_multisite($persist_post) {
     }
     
     //Collect information about the new post 
+	switch_to_blog( $persist_post->destination_id );
     $site_edit_url = get_edit_post_link( $post_id );
     $blog_details  = get_blog_details($persist_post->destination_id);
     $site_name     = $blog_details->blogname;
@@ -377,7 +379,7 @@ function mpd_persist_over_multisite($persist_post) {
     //////////////////////////////////////
     //Go back to the current blog so we can update information about the action that just took place
 	//restore_current_blog();
-	switch_to_blog( $persist_post->destination_id );
+	switch_to_blog( $source_blog_id );
     //////////////////////////////////////
 
     //Use the collected information about the new post to generate a status notice and a link for the user

--- a/inc/media.php
+++ b/inc/media.php
@@ -13,6 +13,10 @@
 function mpd_media_duplicate($post_id, $destination_id){
 
     $the_media      = get_post($post_id);
+	if ( ! $the_media ) {
+		return false;
+	}
+
     $the_media_url  = wp_get_attachment_url( $post_id );
     $wp_filetype    = wp_check_filetype( $the_media_url , null );
     $image_alt      = get_post_meta( $post_id, '_wp_attachment_image_alt', true);
@@ -26,10 +30,10 @@ function mpd_media_duplicate($post_id, $destination_id){
     $attachment     = array(
         'post_mime_type' => $wp_filetype['type'],
         'post_title'     => sanitize_file_name( $file_name ),
-        'post_content'   => $the_media->post_content,
+		'post_content'	 => ( isset( $the_media->post_content ) ) ? $the_media->post_content : '',
         'post_status'    => 'inherit',
-        'post_excerpt'   => $the_media->post_excerpt,
-        'post_name'      => $the_media->post_name,
+		'post_excerpt'	 => ( isset( $the_media->post_excerpt )) ? $the_media->post_excerpt : '',
+		'post_name'		 => ( isset( $the_media->post_name ) ) ? $the_media->post_name : sanitize_file_name( $file_name ),
     );
 
     switch_to_blog($destination_id);

--- a/inc/mpd-functions.php
+++ b/inc/mpd-functions.php
@@ -1188,10 +1188,17 @@ function mpd_add_term_recursively( $post_term, &$orig_all_terms_by_id, &$all_ter
         'parent' => $parent_id
     ));
 
-    $all_terms_by_slug[$post_term->slug] = (object) $new_term;
-	do_action( 'mpd_after_insert_term', $new_term, $post_term, $source_blog_id );
+	//wp_insert_term can return WP_Error for invalid taxonomy
+	//which then causes fatal error if attempting to check term properties on the error object
+	if ( is_wp_error( $new_term ) ) {
+		error_log( 'Could not create term "' . $post_term->name . '" in tax "' . $post_term->taxonomy . '" due to error: ' . $new_term->get_error_message() );
+	} else {
+
+      $all_terms_by_slug[$post_term->slug] = (object) $new_term;
+    do_action( 'mpd_after_insert_term', $new_term, $post_term, $source_blog_id );
     
-    return $new_term['term_id'];
+      return $new_term['term_id'];
+  }
 }
 
 /**

--- a/inc/mpd-functions.php
+++ b/inc/mpd-functions.php
@@ -638,6 +638,13 @@ function mpd_get_image_alt_tags($post_media_attachments){
 
         foreach ($post_media_attachments as $post_media_attachment) {
 
+
+            //pull request fix error in mpd_get_image_alt_tags #54
+            if ( array_key_exists( "object", $post_media_attachment ) ) {
+              $post_id = $post_media_attachment[ "object" ]->ID;
+            } else {
+              $post_id = $post_media_attachment->ID;
+            }
             $alt_tag = get_post_meta($post_media_attachment->ID, '_wp_attachment_image_alt', true);
 
             $alt_tags_to_be_copied[$attachement_count] = $alt_tag;

--- a/inc/mpd-functions.php
+++ b/inc/mpd-functions.php
@@ -645,13 +645,13 @@ function mpd_get_image_alt_tags($post_media_attachments){
             } else {
               $post_id = $post_media_attachment->ID;
             }
-            $alt_tag = get_post_meta($post_media_attachment->ID, '_wp_attachment_image_alt', true);
+			      if ( $post_id ) {
+                $alt_tag = get_post_meta($post_media_attachment->ID, '_wp_attachment_image_alt', true);
 
-            $alt_tags_to_be_copied[$attachement_count] = $alt_tag;
+                $alt_tags_to_be_copied[$attachement_count] = $alt_tag;
 
-            $attachement_count++;
-
-
+                $attachement_count++;
+			      }
         }
 
         $alt_tags_to_be_copied = apply_filters('mpd_alt_tag_array_from_post_content', $alt_tags_to_be_copied, $post_media_attachments);

--- a/inc/mpd-functions.php
+++ b/inc/mpd-functions.php
@@ -720,7 +720,7 @@ function mdp_make_admin_notice($site_name, $site_url, $destination_blog_details)
 
         'source_id'             => get_current_blog_id(),
         'destination_id'        => $destination_blog_details->blog_id,
-        'source_post_id'        => $post->ID,
+		'source_post_id'		 => ($post) ? $post->ID : 0,
         'destination_post_id'   => isset($query['post']) ? $query['post'] : 0
 
     );
@@ -1462,19 +1462,18 @@ function mpd_search($array, $key, $value){
 function mpd_copy_file_to_destination($attachment, $img_url, $post_id = 0, $source_id, $file_id){
 
     $info       = pathinfo($img_url);
-    $file_name  = basename($img_url,'.'.$info['extension']);
+	$ext		 = (isset( $info[ 'extension' ] )) ? '.' . $info[ 'extension' ] : '';
+	$file_name	 = basename( $img_url, $ext );
 
      // Get the upload directory for the current site
     $upload_dir = wp_upload_dir();
     // Make the path to the desired path to the new file we are about to create
     if( wp_mkdir_p( $upload_dir['path'] ) ) {
 
-        $file = $upload_dir['path'] . '/' . $file_name .'.'. $info['extension'];
-
+		$file = $upload_dir[ 'path' ] . '/' . $file_name . $ext;
     } else {
 
-        $file = $upload_dir['basedir'] . '/' . $file_name .'.'. $info['extension'];
-
+		$file = $upload_dir[ 'basedir' ] . '/' . $file_name . $ext;
     }
     
     if($the_original_id = mpd_does_file_exist($file_id, $source_id, get_current_blog_id())){
@@ -1500,12 +1499,11 @@ function mpd_copy_file_to_destination($attachment, $img_url, $post_id = 0, $sour
 
         do_action('mpd_media_image_added', $attach_id, $source_id, $file_id);
         
-    }
-   
-
     return $attach_id;
 
 }
+}
+
 /**
  * 
  * Helper function to get the table name of a perticular table on a specific site
@@ -1790,7 +1788,9 @@ function mpd_process_meta($post_id, $meta_values){
                 }
 
            }
-
+			} else {
+				update_post_meta( $post_id, $key, $value );
+			}
         }
         
     }

--- a/inc/mpd-functions.php
+++ b/inc/mpd-functions.php
@@ -1164,7 +1164,7 @@ function &mpd_hash_obj_by($obj_array = false, $key) {
 
 }
 
-function mpd_add_term_recursively($post_term, &$orig_all_terms_by_id, &$all_terms_by_slug) {
+function mpd_add_term_recursively( $post_term, &$orig_all_terms_by_id, &$all_terms_by_slug, $source_blog_id ) {
 
     if (array_key_exists($post_term->slug, $all_terms_by_slug)) {
 
@@ -1175,8 +1175,7 @@ function mpd_add_term_recursively($post_term, &$orig_all_terms_by_id, &$all_term
 
     if ($post_term->parent != 0) {
 
-        $parent_id = mpd_add_term_recursively($orig_all_terms_by_id[$post_term->parent], $orig_all_terms_by_id, $all_terms_by_slug);
-
+		$parent_id = mpd_add_term_recursively( $orig_all_terms_by_id[ $post_term->parent ], $orig_all_terms_by_id, $all_terms_by_slug, $source_blog_id );
     } else {
 
         $parent_id = 0;
@@ -1190,6 +1189,7 @@ function mpd_add_term_recursively($post_term, &$orig_all_terms_by_id, &$all_term
     ));
 
     $all_terms_by_slug[$post_term->slug] = (object) $new_term;
+	do_action( 'mpd_after_insert_term', $new_term, $post_term, $source_blog_id );
     
     return $new_term['term_id'];
 }
@@ -1207,7 +1207,7 @@ function mpd_add_term_recursively($post_term, &$orig_all_terms_by_id, &$all_term
  * @return array An array of term objects used in the post
  *
  */
-function mpd_set_post_taxonomy_terms($post_id, $source_taxonomy_terms_object) {
+function mpd_set_post_taxonomy_terms( $post_id, $source_taxonomy_terms_object, $source_blog_id ) {
 
     foreach ($source_taxonomy_terms_object as $tax => &$tax_data) {
 
@@ -1227,8 +1227,7 @@ function mpd_set_post_taxonomy_terms($post_id, $source_taxonomy_terms_object) {
 
         foreach ($orig_post_terms as &$post_term) {
 
-            array_push($dest_post_term_ids, mpd_add_term_recursively($post_term, $orig_all_terms_by_id, $all_terms_by_slug));
-
+			array_push( $dest_post_term_ids, mpd_add_term_recursively( $post_term, $orig_all_terms_by_id, $all_terms_by_slug, $source_blog_id ) );
         }
 
         unset($post_term);

--- a/inc/mpd-functions.php
+++ b/inc/mpd-functions.php
@@ -1762,38 +1762,31 @@ function mpd_does_file_exist($source_file_id, $source_id, $destination_id){
 
 }
 
-function mpd_process_meta($post_id, $meta_values){
+function mpd_process_meta( $post_id, $meta_values ) {
 
-    if($meta_values){
+	if ( $meta_values ) {
 
-        foreach ($meta_values as $key => $values) {
-        
-           if(substr( $key, 0, 3 ) !== "mpd_"){
+		foreach ( $meta_values as $key => $values ) {
 
-                foreach ($values as $value) {
+			if ( substr( $key, 0, 3 ) !== "mpd_" ) {
+				if ( is_array( $values ) ) {
+					foreach ( $values as $value ) {
 
-                    //If the data is serialised we need to unserialise it before adding or WordPress will serialise the serialised data
-                    //...which is bad
+						//If the data is serialised we need to unserialise it before adding or WordPress will serialise the serialised data
+						//...which is bad
 
-                    if(is_serialized($value)){
-                     
-                        update_post_meta( $post_id, $key, unserialize($value));
+						if ( is_serialized( $value ) ) {
 
-                    }else{
+							update_post_meta( $post_id, $key, unserialize( $value ) );
+						} else {
 
-                        update_post_meta( $post_id, $key, $value );
-
-                    }
-               
-                }
-
-           }
-			} else {
-				update_post_meta( $post_id, $key, $value );
+							update_post_meta( $post_id, $key, $value );
+						}
+					}
+				} else {
+					update_post_meta( $post_id, $key, $values );
+				}
 			}
-        }
-        
-    }
-    
+		}
+	}
 }
-

--- a/inc/mpd-functions.php
+++ b/inc/mpd-functions.php
@@ -646,7 +646,7 @@ function mpd_get_image_alt_tags($post_media_attachments){
               $post_id = $post_media_attachment->ID;
             }
 			      if ( $post_id ) {
-                $alt_tag = get_post_meta($post_media_attachment->ID, '_wp_attachment_image_alt', true);
+				$alt_tag = get_post_meta( $post_id, '_wp_attachment_image_alt', true );
 
                 $alt_tags_to_be_copied[$attachement_count] = $alt_tag;
 

--- a/inc/mpd-functions.php
+++ b/inc/mpd-functions.php
@@ -1129,10 +1129,13 @@ function mpd_get_post_taxonomy_terms($post_id, $category_only, $destination_id) 
             $post_terms = wp_get_post_terms($post_id, $post_taxonomy);
 
             if (mpd_has_parent_terms($post_terms)) {
+                $all_terms = get_terms( $post_taxonomy );
+                /* JM: remove deprecated parameter
                 $all_terms = get_terms($post_taxonomy, array(
                     'type' => get_post_type($post_id),
                     'hide_empty' => 0
                 ));
+      				 */
             } else {
                 $all_terms = null;
             }
@@ -1192,6 +1195,7 @@ function mpd_add_term_recursively( $post_term, &$orig_all_terms_by_id, &$all_ter
 	//which then causes fatal error if attempting to check term properties on the error object
 	if ( is_wp_error( $new_term ) ) {
 		error_log( 'Could not create term "' . $post_term->name . '" in tax "' . $post_term->taxonomy . '" due to error: ' . $new_term->get_error_message() );
+		return false;
 	} else {
 
       $all_terms_by_slug[$post_term->slug] = (object) $new_term;
@@ -1222,11 +1226,13 @@ function mpd_set_post_taxonomy_terms( $post_id, $source_taxonomy_terms_object, $
 
         $orig_all_terms = array_key_exists(1, $tax_data) ? $tax_data[1] : array();
 
+        $all_terms = get_terms( $tax );
+        /* JM: remove deprecated parameter
         $all_terms = get_terms($tax, array(
             'type' => get_post_type($post_id),
             'hide_empty' => 0
         ));
-
+        */
         $orig_all_terms_by_id   = &mpd_hash_obj_by($orig_all_terms, 'term_id');
         $all_terms_by_slug      = &mpd_hash_obj_by($all_terms, 'slug');
 

--- a/inc/mpd-functions.php
+++ b/inc/mpd-functions.php
@@ -1195,7 +1195,8 @@ function mpd_add_term_recursively( $post_term, &$orig_all_terms_by_id, &$all_ter
 	//which then causes fatal error if attempting to check term properties on the error object
 	if ( is_wp_error( $new_term ) ) {
 		error_log( 'Could not create term "' . $post_term->name . '" in tax "' . $post_term->taxonomy . '" due to error: ' . $new_term->get_error_message() );
-		return false;
+		return $new_term->get_error_data( 'term_exists' );
+		//if term already exists, return the term id from the error data
 	} else {
 
       $all_terms_by_slug[$post_term->slug] = (object) $new_term;


### PR DESCRIPTION
implements #72 with filter and additional parameters on terms
implements #65 with additional filter parameters, also permitting implementation of #63 to create persist post from within bulk copy, also permitting implementation of #61, #60, #59
fixes #69 by avoiding copy again to target blog: useful when called from bulk copy where easy to accidentally include some posts already copied
fixes #68 
fixes #67 
fixes #66 
fixes #64 

